### PR TITLE
add a special note that quay.io images might not contain the latest changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ The following repositories describe the underlying API and controllers for the a
 
 There are demonstrations available at https://github.com/open-cluster-management/demo-subscription-gitops .
 
+### Deployment images
+
+The open-cluster-management project uses `quay.io` to host deployment images. These images might not contain the latest changes. Following a merged pull request, please wait up to an hour for the images to be updated.
+
 ### Community meetings
 
 The community meets on a bi-weekly cadence on Thursday at 15:30 UTC.

--- a/docs/template_README.md
+++ b/docs/template_README.md
@@ -21,6 +21,9 @@ Go to the [Contributing guide](CONTRIBUTING.md) to learn how to get involved.
 
 - Steps for deployment:
 
+  - List of steps for deployment.
+  - Please be aware of the community's [deployment images](https://github.com/open-cluster-management/community#deployment-images) special note.
+
 - Check the [Security guide](SECURITY.md) if you need to report a security issue.
 
 ## References


### PR DESCRIPTION
As discussed, we want to let the public know the `quay.io` images might not contain the latest changes. It can be up to an hour before the image-mirroring occur and copy the images over to quay.

Signed-off-by: Mike Ng <ming@redhat.com>