### PR TITLE
Add SIG Policy for OCM's sub-component Policy add-on scope and governance

### DIFF
--- a/sig-architecture/api_changes.md
+++ b/sig-architecture/api_changes.md
@@ -11,7 +11,7 @@ This document is oriented at developers who want to change existing APIs for Ope
 
 ### Things you should consider before you change the APIs
 
-Before attempting a change to the API, you should familiarize yourself with a number of [existing API types](https://github.com/open-cluster-management/api) and with the API conventions.
+Before attempting a change to the API, you should familiarize yourself with a number of [existing API types](https://github.com/open-cluster-management-io/api) and with the API conventions.
 
 You should also consider the compatibility of the API changes. Open Cluster Management considers forwards and backwards compatibility of its APIs as top priority.
 

--- a/sig-policy/README.md
+++ b/sig-policy/README.md
@@ -1,0 +1,41 @@
+# SIG Policy
+
+The SIG Policy maintains and evolves the design principles of Open Cluster Management's sub-component Policy add-on, and provides a consistent body of expertise necessary to ensure policy related architectural consistency over time.
+
+The [Policy charter](policy-charter.md) defines the scope and governance of the sig-policy.
+
+## Leadership
+
+### Chairs
+The Chairs of the SIG run operations and processes governing the SIG.
+
+* Matt Prahl (**[@mprahl](https://github.com/mprahl)**), Red Hat
+* Dale Haiducek (**[@dhaiducek](https://github.com/dhaiducek)**), Red Hat
+
+## Subprojects
+
+The following [subprojects][subproject-definition] are owned by sig-policy:
+### config-policy-controller
+Configuration Policy Controller
+- **Owners:**
+  - [config-policy-controller](https://github.com/open-cluster-management-io/config-policy-controller/blob/main/OWNERS)
+### governance-policy-propagator
+Governance Policy Propagator
+- **Owners:**
+  - [governance-policy-propagator](https://github.com/open-cluster-management-io/governance-policy-propagator/blob/main/OWNERS)
+### governance-policy-spec-sync
+Governance Policy Spec Sync
+- **Owners:**
+  - [governance-policy-spec-sync](https://github.com/open-cluster-management-io/governance-policy-spec-sync/blob/main/OWNERS)
+### governance-policy-template-sync
+Governance Policy Template Sync
+- **Owners:**
+  - [governance-policy-template-sync](https://github.com/open-cluster-management-io/governance-policy-template-sync/blob/main/OWNERS)
+### governance-policy-status-sync
+Governance Policy Status Sync
+- **Owners:**
+  - [governance-policy-status-sync](https://github.com/open-cluster-management-io/governance-policy-status-sync/blob/main/OWNERS)
+### ocm-kustomize-generator-plugins
+Policy Generator
+- **Owners:**
+  - [ocm-kustomize-generator-plugins](https://github.com/open-cluster-management-io/ocm-kustomize-generator-plugins/blob/main/OWNERS)

--- a/sig-policy/policy-charter.md
+++ b/sig-policy/policy-charter.md
@@ -2,15 +2,23 @@
 
 ## Scope
 
-SIG Policy covers governance capability, security remediation, and configuration management for the Open Cluster Management (OCM) project.
+The Policy SIG covers governance capability, security remediation, and configuration management for the Open Cluster
+Management (OCM) project.
+
+In particular, it currently includes the OCM Policy Framework, which is responsible for top-level `Policy` objects and
+syncing those objects between the Hub and managed clusters. It additionally includes the controllers that process the
+down-level policies such as `ConfigurationPolicy`.
 
 ### In scope
 
 #### Code, Binaries and Services
 
 - Review and approve policy related OCM enhancements.
-- APIs used for OCM policies.
-- Tools and documentation to aid in ecosystem tool interoperability around policy (e.g. Policy Generator)
+- The APIs in the `policy.open-cluster-management.io` API group. The API versioning and deprecation strategy
+  follows the OCM
+  [graduation criteria](https://github.com/open-cluster-management-io/enhancements/tree/main/guidelines#graduation-criteria).
+- Tools and documentation to aid in ecosystem tool interoperability around policy (e.g. Policy Generator).
+- Enhancements that affect security and scalability will often be discussed at the OCM community level.
 
 #### Cross-cutting and Externally Facing Processes
 

--- a/sig-policy/policy-charter.md
+++ b/sig-policy/policy-charter.md
@@ -1,0 +1,35 @@
+# SIG Policy charter
+
+## Scope
+
+SIG Policy covers governance capability, security remediation, and configuration management for the Open Cluster Management (OCM) project.
+
+### In scope
+
+#### Code, Binaries and Services
+
+- Review and approve policy related OCM enhancements.
+- APIs used for OCM policies.
+- Tools and documentation to aid in ecosystem tool interoperability around policy (e.g. Policy Generator)
+
+#### Cross-cutting and Externally Facing Processes
+
+- A discussion platform for solving OCM policy related development and management problems.
+- Represent the needs and persona of OCM policy developers and operators.
+
+### Out of scope
+
+SIG Policy scope does not include:
+
+- Any non policy related OCM projects.
+- Private vulnerability response (belongs to the PSC), including:
+    - Embargoed vulnerability management
+    - Bug bounty submission triage and management
+    - Non-public vulnerability collection, triage, and disclosure
+- Security audit for all other OCM components.
+
+### Additional responsibilities of Chairs
+
+- Report the Project status at events and community meetings, when possible.
+- Actively promote diversity and inclusion in the Community.
+- Uphold the Code of Conduct, especially in terms of personal behavior and responsibility.


### PR DESCRIPTION
The policy repos owners would like to have more direct control over their policy component
This PR is to propose a SIG Policy within the OCM community.

Signed-off-by: Mike Ng <ming@redhat.com>