### PR TITLE
Add the MAINTANERS.md.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,66 @@
+# Maintainers
+
+## The maintainer list of core ocm(names are in alphabetical order)
+
+Note: The maintainers of integrations and addons **are not** listed here, as they are responsible for their own repositories.
+We enthusiastically welcome contributors to create addons, whether within or outside the ocm-io organization. All integrations and addons are listed on [this page](https://open-cluster-management.io/getting-started/integration/).
+
+
+* Chunlin Yang (Redhat, @clyang82)
+* David Eads (Redhat, @deads2k)
+* Dong Beiqing (eBay, @dongbeiqing)
+* Hao Lin (eBay, @haowells)
+* Jian Qiu (Redhat, @qiujian16)
+* Jian Zhu (Redhat, @zhujian7)
+* Le Yang (Redhat, @elgnay)
+* LongLong Cao (Redhat, @morvencao)
+* Mike Ng (Redhat, @mikeshng)
+* Qing Hao (Redhat, @haoqing0110)
+* Tamal Saha (AppsCode, @tamalsaha)
+* Wei Liu (Redhat, @skeeey)
+* Zhao Xue (Redhat, @xuezhaojun)
+* Zhiwei Yin (Redhat, @zhiweiyin318)
+
+## The maintainers in different areas of OCM
+
+### [OCM CORE](https://github.com/open-cluster-management-io/ocm)
+* Maintainers for specific areas:
+    * [api](https://github.com/open-cluster-management-io/api)
+        * Jian Qiu
+        * David Eads
+    * `registration`
+        * Le Yang
+        * Wei Liu
+        * Zhao Xue
+    * `work`
+        * Le Yang
+        * Jian Zhu
+    * `placement`
+        * Le Yang
+        * Qing Hao
+    * `operator`
+        * Jian Zhu
+        * Zhiwei Yin
+        * Dong Beiqing
+        * Hao Lin
+
+### SDK and Tools
+* [addon-framework](https://github.com/open-cluster-management-io/addon-framework)
+    * Jian Qiu
+    * Le Yang
+    * Zhiwei Yin
+    * Jian Zhu
+* [sdk-go](https://github.com/open-cluster-management-io/sdk-go/blob/main/OWNERS)
+    * Jian Qiu
+    * David Eads
+* [clusteradm](https://github.com/open-cluster-management-io/clusteradm)
+    * Jian Qiu
+    * Zhu Jian
+
+### Community and Docs
+* [community](https://github.com/open-cluster-management-io/community)
+    * Jian Qiu
+    * Mike Ng
+* [website](https://github.com/open-cluster-management-io/open-cluster-management-io.github.io)
+    * Jian Qiu
+    * Mike Ng


### PR DESCRIPTION
After the PR is merged, we should also update information in cncf repo: https://github.com/cncf/foundation/blob/2a58de4421a73db2c72f4ebe0795d8533ad1901e/project-maintainers.csv?plain=1#L1004
---
## The motivation

* Community users should using this doc to quickly find the maintainer for their problem in a specific area of ocm.
* Quick glice to show the company/org of every maintainer.

## The 2 options we have, and Pros and Cons

After going throught the [graduated projects of cncf](https://contribute.cncf.io/contributors/projects/#graduated-projects),  we have found 2 pattern of MAINTAINER list.

### Type1, json or yaml format, IaC, configuration style file

For examples:
* [istio](https://github.com/istio/community/blob/78c6ecb4043dcdbedb314f1e875f12415799990b/org/teams.yaml#L2)
* [cilium](https://github.com/cilium/community/tree/1546d8d67559df68eca8a13a94595db78d921688/ladder/teams)

Usually, the project's infrustructure team will setup a bot or ci tool to sync these teams configuration to [github teams](https://docs.github.com/en/organizations/organizing-members-into-teams/about-teams), then each repo under the org can leverage github teams to create the [codeowners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file.

Using cilium for an example:
1. it has a repo [team-manager](https://github.com/cilium/team-manager) to sync the configuration files to their github org teams.
2. it using [a codeowners file](https://github.com/cilium/cilium/blob/main/CODEOWNERS) instead of owners file in their main repo.

The Pros are:
1. github teams plus codeowners can bring more fine-grained permission management. 
2. the sync from "file changes" to actual projects is smooth, no second operation are needed.

The Cons are:
1. it's complex to setup.
3. it needs extra effort in tooling.

### Type2, markdown format, human read friendly, document style file

For examples:
* [kubevela](https://github.com/kubevela/community/blob/main/OWNERS.md)
* [prometheus](https://github.com/prometheus/prometheus/blob/main/MAINTAINERS.md)

Obviously, it's much easier to setup but it's not suitable when we have a lot of sub projects or work groups or teams.

### The path

We will first add a type 2 MAINTAINER.md, in this step, we will discuss and figure out what teams and work-group we need to create.

Next, when we have enough members and maintainers we will invest the more automatic way -- to create a type 1 MAINTAINER list, we may even can recurit from the community.