### PR TITLE
doc: fix broken link for agenda and topics.

### DIFF
--- a/MISSION.md
+++ b/MISSION.md
@@ -54,7 +54,7 @@ Meeting recordings will be posted to a YouTube channel for offline viewing.
 
 The community meets on a weekly cadence alternating between Friday at 01:30 UTC and Thursday at 14:00 UTC. The Thursday meeting is on demand basis.
 
-Meeting Agenda and Topics can be found here: https://github.com/open-cluster-management-io/community/projects/1.
+Meeting Agenda and Topics can be found [here](https://docs.google.com/document/d/1CPXPOEybBwFbJx9F03QytSzsFQImQxeEtm8UjhqYPNg).
 
 ## Communication
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The office hours is on bi-weekly cadence Wednesday at 17:00 UTC.
 
 Refer to the meeting calendar for the latest schedule: https://calendar.google.com/calendar/u/0/embed?src=openclustermanagement@gmail.com.
 
-Meeting Agenda and Topics can be found here: https://github.com/open-cluster-management-io/community/projects/1.
+Meeting Agenda and Topics can be found [here](https://docs.google.com/document/d/1CPXPOEybBwFbJx9F03QytSzsFQImQxeEtm8UjhqYPNg).
   
   Meeting dial-in details, meeting notes and agendas are announced and published to the [open-cluster-management mailing list on Google Groups](https://groups.google.com/g/open-cluster-management).
 


### PR DESCRIPTION
GitHub phased out the old project dashboard.

The [new](https://github.com/orgs/open-cluster-management-io/projects/9) one is in place but it doesn't look that nice because every card needs to be a GitHub issue or it will have the word "Draft" in it. 

This PR is to point the agenda and topics to the ocm google doc.