### PR TITLE
Add Meng Yan as addon-contrib maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -20,6 +20,7 @@ We enthusiastically welcome contributors to create addons, whether within or out
 * Joshua Packer (Red Hat, @jnpacker)
 * Le Yang (Red Hat, @elgnay)
 * LongLong Cao (Red Hat, @morvencao)
+* Meng Yan (Red Hat, @yanmxa)
 * Mike Ng (Red Hat, @mikeshng)
 * Qing Hao (Red Hat, @haoqing0110)
 * Ramesh Krishna (Guidewire Software, @ramekris3163)
@@ -84,6 +85,8 @@ We enthusiastically welcome contributors to create addons, whether within or out
     * Jian Qiu
     * Joshua Packer
     * Mike Ng
+* [addon-contrib](https://github.com/open-cluster-management-io/addon-contrib)
+    * Meng Yan
 * [website](https://github.com/open-cluster-management-io/open-cluster-management-io.github.io)
     * Jian Qiu
     * Mike Ng


### PR DESCRIPTION
## Summary
- Add `Meng Yan` (@yanmxa) to the core OCM maintainer list
- Add `addon-contrib` repo under "Community and Docs" section with Meng Yan as maintainer

/cc @qiujian16 @mikeshng

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project maintainer information in documentation to reflect current team structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->